### PR TITLE
Fix two typos in the readme. Markdown link labels and URLs were inverted.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ CodeMirror UI
 =============
 
 CodeMirrorUI is a simple interface written by Jeremy Green to act as a 
-wrapper around the [http://codemirror.net/](CodeMirror) text editor widget by Marijn Haverbeke.
+wrapper around the [CodeMirror](http://codemirror.net/) text editor widget by Marijn Haverbeke.
 CodeMirror is a syntax highlighter and formatter that makes it much easier to edit source code in a browser.
-ComeMirrorUI is a wrapper that adds interface functionality for many functions that are already built into CodeMirror itself.
+CodeMirrorUI is a wrapper that adds interface functionality for many functions that are already built into CodeMirror itself.
 Functionality includes undo, redo, jump to line, reindent selection, and reindent entire document. 
 Two options for find/replace are also available.  It is based on the MirrorFrame example that Marijn included with CodeMirror.
 
@@ -49,7 +49,7 @@ Please see index.html for examples and many additional details.
 Acknowledgements
 ----------------------
 
-Thanks to Marijn Haverbeke for creating and releasing [http://codemirror.net/](CodeMirror) in the first place.  
-Whithout his excellent contribution to the community this project would have no reason to exist.
+Thanks to Marijn Haverbeke for creating and releasing [CodeMirror](http://codemirror.net/) in the first place.  
+Without his excellent contribution to the community this project would have no reason to exist.
 
-Thanks to Mark James of famfamfam.com for his [http://www.famfamfam.com/lab/icons/silk/](Silk Icons).
+Thanks to Mark James of famfamfam.com for his [Silk Icons](http://www.famfamfam.com/lab/icons/silk/).


### PR DESCRIPTION
Fix two typos in the readme. Markdown link labels and URLs were inverted.
