### PR TITLE
Fixed undo/redo visibility and onChange

### DIFF
--- a/css/codemirror-ui.css
+++ b/css/codemirror-ui.css
@@ -42,7 +42,9 @@ input.codemirror-ui-checkbox{
 }
 
 .codemirror-ui-button.inactive{
-	background:#ccc;
+	-ms-filter:"progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
+	filter: alpha(opacity=50);
+	opacity: .5;
 }
 
 .codemirror-ui-wrap{


### PR DESCRIPTION
Hi Jeremy! Thanks a lot for your codemirror-ui! I first started to reuse pieces of it but it is better to join, so here is my first contribution. As more then one undo/redo button per editor makes no sense, I removed the arrays.

The "bind" method should definitely not be public for better compatibility with other JavaScript libraries and the whole code should not pollute the global namespace. Some pieces of the code can be removed (for instance initWordWrapControl) and cleaned up before proceeding.
