### PR TITLE
Overhaul of the search / replace / replace-all functionality

### DIFF
--- a/js/codemirror-ui.js
+++ b/js/codemirror-ui.js
@@ -239,13 +239,23 @@ CodeMirrorUI.prototype = {
     }
   },
   replace: function() {
+  	var findString = this.findString.value,
+  	replaceString = this.replaceString.value,
+  	isCaseSensitive = this.caseSensitive.checked,
+  	isRegex = this.regex.checked,
+  	regFindString = isRegex ? new RegExp(findString, !isCaseSensitive ? "i" : "") : "";
+
     if (this.replaceAll.checked) {
-      var cursor = this.mirror.getSearchCursor(this.findString.value, 0, !this.caseSensitive.checked);
+      var cursor = this.mirror.getSearchCursor(isRegex ? regFindString : findString, 0, !isCaseSensitive);
       while (cursor.findNext())
-        this.mirror.replaceRange(this.replaceString.value,cursor.from(),cursor.to())
+        this.mirror.replaceRange(
+            isRegex ? cursor.pos.match[0].replace(regFindString, replaceString) : replaceString
+            ,cursor.from(),cursor.to());
         //cursor.replace(this.replaceString.value);
     } else {
-      this.mirror.replaceRange(this.replaceString.value,this.cursor.from(),this.cursor.to())
+      this.mirror.replaceRange(
+        isRegex ? this.cursor.pos.match[0].replace(regFindString, replaceString) : replaceString
+        ,this.cursor.from(),this.cursor.to())
       //this.cursor.replace(this.replaceString.value);
       this.find();
     }

--- a/js/codemirror-ui.js
+++ b/js/codemirror-ui.js
@@ -240,7 +240,7 @@ CodeMirrorUI.prototype = {
   },
   replace: function() {
     if (this.replaceAll.checked) {
-      var cursor = this.mirror.getSearchCursor(this.findString.value, this.mirror.getCursor(), !this.caseSensitive.checked);
+      var cursor = this.mirror.getSearchCursor(this.findString.value, 0, !this.caseSensitive.checked);
       while (cursor.findNext())
         this.mirror.replaceRange(this.replaceString.value,cursor.from(),cursor.to())
         //cursor.replace(this.replaceString.value);

--- a/js/codemirror-ui.js
+++ b/js/codemirror-ui.js
@@ -207,6 +207,7 @@ CodeMirrorUI.prototype = {
     this.buttonFrame.appendChild(findBar);
   },
   find: function( start ) {
+    var isCaseSensitive = this.caseSensitive.checked;
     if(start == null){
       start = this.mirror.getCursor();
     }
@@ -216,17 +217,17 @@ CodeMirrorUI.prototype = {
       return;
     }
     if (this.regex.checked) {
-      findString = new RegExp(findString);
+      findString = new RegExp(findString, !isCaseSensitive ? "i" : "");
     }
 
-    this.cursor = this.mirror.getSearchCursor(findString, start, !this.caseSensitive.checked );
+    this.cursor = this.mirror.getSearchCursor(findString, start, !isCaseSensitive );
     var found = this.cursor.findNext();
     if (found) {
       this.mirror.setSelection(this.cursor.from(),this.cursor.to())
       //this.cursor.select();
     } else {
       if (confirm("No more matches.  Should we start from the top?")) {
-        this.cursor = this.mirror.getSearchCursor(findString, 0, !this.caseSensitive.checked);
+        this.cursor = this.mirror.getSearchCursor(findString, 0, !isCaseSensitive);
         found = this.cursor.findNext();
         if (found) {
           this.mirror.setSelection(this.cursor.from(),this.cursor.to())


### PR DESCRIPTION
1. Made regular expression searches obey the case-sensitivity checkbox
2. Made replace-all start from the top of the document, otherwise only occurrences after the first one are replaced
3. More intelligent handling of regular expression searches (see _Further Explanation_ below...)
## Further Explanation of point 3

Just trying to mimic the regular expression search / replace functionality found in text editors such as Texmate or Coda. 
#### The short explanation is:

Now _Replace / Replace-all_ is aware of capturing groups in the find string, and back-references in the replace string.
#### The long explanation is depicted in the following example:

Say in the example loaded file in index.html, you wanted to replace all `ctrl_[key]` members of the `keyBindings` object with `[key]_ctrl`:
1. Tick the Regex and replace-all checkboxes
2. Place `ctrl_([^:]*):` in the search box
3. Place `$1_ctrl:` in the replace box
4. Click Replace
    Now it looks like:
`var keyBindings = {
        enter: "newline-and-indent",
        tab: "reindent-selection",
        z_ctrl: "undo",
        y_ctrl: "redo",
        backspace_ctrl: "undo-for-safari (which blocks ctrl-z)",
        bracket_ctrl: "highlight-brackets",
        shift_bracket_ctrl: "jump-to-matching-bracket"
};`

Let me know if the above does not make sense :-)
