### PR TITLE
Add a 'save' button and new options 'saveCallback' and 'imagePath'

### DIFF
--- a/css/codemirror-ui.css
+++ b/css/codemirror-ui.css
@@ -1,5 +1,7 @@
 .codemirror-ui-button-frame{
-	border:1px solid #ccc;
+	border-top:1px solid #ccc;
+	border-left:1px solid #ccc;
+	border-right:1px solid #ccc;
 	background:#eee;
 	position:relative;
 }
@@ -97,7 +99,6 @@ iframe{
 
 .CodeMirror{
 	border:1px solid #ccc;
-	border-top:0px;
 	background:white;
 }
 

--- a/js/codemirror-ui.js
+++ b/js/codemirror-ui.js
@@ -23,7 +23,7 @@ CodeMirrorUI.prototype = {
     this.setDefaults(this.options, defaultOptions);
 
     this.buttonDefs = {
-      'save': ["Save", "save", this.options.imagePath + "/page_save.png", this.options.saveCallback],
+      'save': ["Save", "save", this.options.imagePath + "/page_save.png", this.save],
       'search': ["Search/Replace", "find_replace_popup", this.options.imagePath + "/find.png", this.find_replace_popup],
       'searchClose': ["Close", "find_replace_popup_close", this.options.imagePath + "/cancel.png", this.find_replace_popup_close],
       'searchDialog': ["Search/Replace", "find_replace_window", this.options.imagePath + "/find.png", this.find_replace_window],
@@ -338,6 +338,10 @@ CodeMirrorUI.prototype = {
       this.addClass(this.redoButton, 'inactive');
     }
     //alert("undo size = " + his['undo'] + " and redo size = " + his['redo']);
+  },
+  save: function() {
+    this.options.saveCallback();
+    this.addClass(this.saveButton, 'inactive');
   },
   undo: function() {
     this.mirror.undo();

--- a/js/codemirror-ui.js
+++ b/js/codemirror-ui.js
@@ -13,23 +13,26 @@ CodeMirrorUI.prototype = {
   initialize: function(textarea, options, mirrorOptions) {
     var defaultOptions = {
       searchMode: 'popup', // other options are 'inline' and 'dialog'.  The 'dialog' option needs work.
+      imagePath: '../images/silk',
       path: 'js',
-      buttons: ['search', 'undo', 'redo', 'jump', 'reindentSelection', 'reindent','about']
+      buttons: ['search', 'undo', 'redo', 'jump', 'reindentSelection', 'reindent','about'],
+      saveCallback: function() {},
     }
     this.textarea = textarea
     this.options = options;
     this.setDefaults(this.options, defaultOptions);
 
     this.buttonDefs = {
-      'search': ["Search/Replace", "find_replace_popup", this.options.path + "../images/silk/find.png", this.find_replace_popup],
-      'searchClose': ["Close", "find_replace_popup_close", this.options.path + "../images/silk/cancel.png", this.find_replace_popup_close],
-      'searchDialog': ["Search/Replace", "find_replace_window", this.options.path + "../images/silk/find.png", this.find_replace_window],
-      'undo': ["Undo", "undo", this.options.path + "../images/silk/arrow_undo.png", this.undo],
-      'redo': ["Redo", "redo", this.options.path + "../images/silk/arrow_redo.png", this.redo],
-      'jump': ["Jump to line #", "jump", this.options.path + "../images/silk/page_go.png", this.jump],
-      'reindentSelection': ["Reformat selection", "reindentSelect", this.options.path + "../images/silk/text_indent.png", this.reindentSelection],
-      'reindent': ["Reformat whole document", "reindent", this.options.path + "../images/silk/page_refresh.png", this.reindent],
-      'about': ["About CodeMirror-UI", "about", this.options.path + "../images/silk/help.png", this.about]
+      'save': ["Save", "save", this.options.imagePath + "/page_save.png", this.options.saveCallback],
+      'search': ["Search/Replace", "find_replace_popup", this.options.imagePath + "/find.png", this.find_replace_popup],
+      'searchClose': ["Close", "find_replace_popup_close", this.options.imagePath + "/cancel.png", this.find_replace_popup_close],
+      'searchDialog': ["Search/Replace", "find_replace_window", this.options.imagePath + "/find.png", this.find_replace_window],
+      'undo': ["Undo", "undo", this.options.imagePath + "/arrow_undo.png", this.undo],
+      'redo': ["Redo", "redo", this.options.imagePath + "/arrow_redo.png", this.redo],
+      'jump': ["Jump to line #", "jump", this.options.imagePath + "/page_go.png", this.jump],
+      'reindentSelection': ["Reformat selection", "reindentSelect", this.options.imagePath + "/text_indent.png", this.reindentSelection],
+      'reindent': ["Reformat whole document", "reindent", this.options.imagePath + "/page_refresh.png", this.reindent],
+      'about': ["About CodeMirror-UI", "about", this.options.imagePath + "/help.png", this.about]
     };
 
     //place = CodeMirror.replace(place)
@@ -67,6 +70,7 @@ CodeMirrorUI.prototype = {
       this.initPopupFindControl();
     }
 
+    if (this.saveButton) this.addClass(this.saveButton,'inactive');
     if (this.undoButton) this.addClass(this.undoButton,'inactive');
     if (this.redoButton) this.addClass(this.redoButton,'inactive');	
   },
@@ -291,6 +295,9 @@ CodeMirrorUI.prototype = {
     img.func = func.bind(this);
     button.appendChild(img);
     frame.appendChild(button);
+    if (action == 'save') {
+      this.saveButton = button;
+    }
     if (action == 'undo') {
       this.undoButton = button;
     }
@@ -319,8 +326,10 @@ CodeMirrorUI.prototype = {
     }
     var his = this.mirror.historySize();
     if (his['undo'] > 0) {
+      this.removeClass(this.saveButton, 'inactive');
       this.removeClass(this.undoButton, 'inactive');
     } else {
+      this.addClass(this.saveButton, 'inactive');
       this.addClass(this.undoButton, 'inactive');
     }
     if (his['redo'] > 0) {


### PR DESCRIPTION
Not much to say about the 'save' button, the implementation isn't perfect yet but works. In the future, the button should also be disabled ('inactive') when the user undos/redos to the last saved state.

The 'imagePath' option is a necessity when your asset setup differs from the hardcoded one, especially when you have a themes folder that is determined at runtime.
