### PR TITLE
Replace All fix

### DIFF
--- a/js/codemirror-ui.js
+++ b/js/codemirror-ui.js
@@ -238,16 +238,20 @@ CodeMirrorUI.prototype = {
     }
   },
   replace: function() {
-    if (this.replaceAll.checked) {
-      var cursor = this.mirror.getSearchCursor(this.findString.value, this.mirror.getCursor(), !this.caseSensitive.checked);
-      while (cursor.findNext())
-        this.mirror.replaceRange(this.replaceString.value,cursor.from(),cursor.to())
-        //cursor.replace(this.replaceString.value);
-    } else {
-      this.mirror.replaceRange(this.replaceString.value,this.cursor.from(),this.cursor.to())
-      //this.cursor.replace(this.replaceString.value);
-      this.find();
-    }
+    query = this.findString.value;
+    text = this.replaceString.value;
+	  if (this.replaceAll.checked) {
+	        for (var cursor = this.mirror.getSearchCursor(query); cursor.findNext();) {
+	          if (typeof query != "string") {
+	            var match = this.mirror.getRange(cursor.from(), cursor.to()).match(query);
+	            cursor.replace(text.replace(/\$(\d)/, function(w, i) {return match[i];}));
+	          } else {cursor.replace(text)};
+	        }
+	    } else {
+		    this.mirror.replaceRange(text,this.cursor.from(),this.cursor.to())
+		    //singleCursor.replace(this.replaceString.value);
+		    this.find();
+	    }
   },
   initWordWrapControl: function() {
     var wrapDiv = document.createElement("div");


### PR DESCRIPTION
This fixes the issue I reported earlier. What would happen is that Replace All was only using findNext(), so anything found beforehand was not replaced. When I added a findPrevious() while loop to replace matching items before the current cursor location what was happening was that if you were replacing the root of a word (e.g. you were replacing 'fast' with 'faster') it would get stuck on the root and repeatedly replace it getting a result like 'fasterererererer', and I'm definitely not that fast. I changed the replace all portion of the code with the replace all function from the CodeMirror search and replace demo from the CodeMirror site. While I don't know all of the nitty gritty, it appears to replace all of them in one fell swoop in a functional manner rather than looping through the words -- avoiding the problem altogether.

Known bug: I haven't implemented a better function for replace (singular) which can still fall into the root-word-loop problem. I will work on implementing the singular function from the CodeMirror site to fix this bug as well, as time permits
