### PR TITLE
Fix for IE7

### DIFF
--- a/js/codemirror-ui.js
+++ b/js/codemirror-ui.js
@@ -294,7 +294,15 @@ CodeMirrorUI.prototype = {
     button.func = func.cmuiBind(this);
     button.onclick = function(event) {
       //alert(event.target);
-      event.target.func();
+      
+      //normalize for IE
+      event = event ? event : window.event;
+      if (typeof event.target == 'undefined') {
+        var target = event.srcElement;
+      } else {
+      	var target = event.target;
+      }
+      target.func();
       return false;
       //this.self[action].call(this);
       //eval("this."+action)();


### PR DESCRIPTION
IE7 will throw an error whenever you click any of the CodeMirrorUI buttons, because IE has an (of course) non-standard implementation of the event.target attribute. IE instead uses event.srcElement, but it can't even check for event.target being undefined because passing in events is borked too -- so we have to take the event from the window and overwrite the function event for IE, then check for it to be undefined. The behavior is unchanged for standards compliant browsers
